### PR TITLE
Update TaskManager.h to avoid overflow

### DIFF
--- a/src/TaskManager.h
+++ b/src/TaskManager.h
@@ -30,7 +30,7 @@ public:
 
     void Setup();
     // for esp8266, its always 3.2 seconds
-    void Loop(uint8_t watchdogTimeOutFlag = WDTO_500MS);
+    void Loop(uint16_t watchdogTimeOutFlag = WDTO_500MS);
     void StartTask(Task* pTask);
     void StopTask(Task* pTask);
     TaskState StatusTask(Task* pTask);


### PR DESCRIPTION
The variable type of watchdogTimeOutFlag is uint8_t, and it will overflow with the define on line 19.
Similar change would have to be made to TaskManager.cpp.