### PR TITLE
Update TaskManager.h and TaskManager.cpp to avoid watchdogTimeOutFlag overflow

### DIFF
--- a/src/TaskManager.cpp
+++ b/src/TaskManager.cpp
@@ -86,7 +86,7 @@ TaskState TaskManager::StatusTask(Task* pTask)
     return pTask->_taskState;
 }
 
-void TaskManager::Loop(uint8_t watchdogTimeOutFlag)
+void TaskManager::Loop(uint16_t watchdogTimeOutFlag)
 {
     uint32_t currentTick = GetTaskTime();
     uint32_t deltaTime = currentTick - _lastTick;

--- a/src/TaskManager.h
+++ b/src/TaskManager.h
@@ -30,7 +30,7 @@ public:
 
     void Setup();
     // for esp8266, its always 3.2 seconds
-    void Loop(uint8_t watchdogTimeOutFlag = WDTO_500MS);
+    void Loop(uint16_t watchdogTimeOutFlag = WDTO_500MS);
     void StartTask(Task* pTask);
     void StopTask(Task* pTask);
     TaskState StatusTask(Task* pTask);


### PR DESCRIPTION
The type of variable watchdogTimeOutFlag is too small and even the define on line 19 of TaskManager.h would overflow it.