### PR TITLE
Adding Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/en/latest/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/en/latest/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/en/latest/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=examples/BlinkUsingCustomTask
+    - PLATFORMIO_CI_SRC=examples/BlinkUsingTaskFunction
+    - PLATFORMIO_CI_SRC=examples/BlinkUsingTaskMacros
+    - PLATFORMIO_CI_SRC=examples/ButtonInterrupt
+    - PLATFORMIO_CI_SRC=examples/ButtonTask
+    - PLATFORMIO_CI_SRC=examples/MessageTask
+    - PLATFORMIO_CI_SRC=examples/RotaryEncoder
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio ci --board=uno --board=megaatmega2560 --board=esp12e --lib="."

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ install:
     - pip install -U platformio
 
 script:
-    - platformio ci --board=uno --board=megaatmega2560 --board=esp12e --lib="."
+    - platformio ci --board=uno --board=megaatmega2560 --board=esp12e --board=leonardo --lib="."

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     - PLATFORMIO_CI_SRC=examples/BlinkUsingCustomTask
     - PLATFORMIO_CI_SRC=examples/BlinkUsingTaskFunction
     - PLATFORMIO_CI_SRC=examples/BlinkUsingTaskMacros
-    - PLATFORMIO_CI_SRC=examples/ButtonInterrupt
+    - PLATFORMIO_CI_SRC=examples/ButtonInterrupt PLATFORMIO_CI_BOARDS_ARGS="--board=uno --board=megaatmega2560 --board=leonardo"
     - PLATFORMIO_CI_SRC=examples/ButtonTask
     - PLATFORMIO_CI_SRC=examples/MessageTask
     - PLATFORMIO_CI_SRC=examples/RotaryEncoder
@@ -42,4 +42,4 @@ install:
     - pip install -U platformio
 
 script:
-    - platformio ci --board=uno --board=megaatmega2560 --board=esp12e --board=leonardo --lib="."
+    - if [[ $PLATFORMIO_CI_BOARDS_ARGS ]]; then bash -c 'platformio ci --lib="." $PLATFORMIO_CI_BOARDS_ARGS'; else bash -c 'platformio ci --lib="." --board=uno --board=megaatmega2560 --board=esp12e --board=leonardo'; fi


### PR DESCRIPTION
Hi @Makuna 

i added a Travis CI configuration to trigger a test build using [platform.io](http://platformio.org/) for your library. [Example](https://travis-ci.org/SirUli/Task) from my fork.

Helps a bit to see if the code compiles for the target board (feel free to add additional or different ones). E.g. in a first try i overlooked that the ButtonInterrupt is not meant for ESP8266 and therefore the build failed (https://travis-ci.org/SirUli/Task/builds/139249455). When integrated with GitHub, you can see in the pull request if it compiles by the way ;)

Best Regards,
Uli