### PR TITLE
Fix crash Stop and pNext

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -57,7 +57,8 @@ public:
     Task(uint32_t timeInterval) :
             _timeInterval(timeInterval),
             _remainingTime(0),
-            _taskState(TaskState_Stopped)
+            _taskState(TaskState_Stopped),
+            _pNext(NULL)
     {
     }
 
@@ -102,8 +103,11 @@ private:
     }
     void Stop()
     {
-        OnStop();
-        _taskState = TaskState_Stopping;
+        if (_taskState == TaskState_Running)
+        {
+            OnStop();
+            _taskState = TaskState_Stopping;
+        }
     }
 };
 


### PR DESCRIPTION
Crash occurs if you make a Stop and then a Start.
Then you should check if it's really running.

Set NULL in pNext pointer to avoid junk.